### PR TITLE
Make conflict solving more robust

### DIFF
--- a/client/agent.py
+++ b/client/agent.py
@@ -92,8 +92,8 @@ class Agent:
         self.tracker = Tracker(state.find_agent(self.name))
         self.tracker.estimate(state)
 
-    def plan(self, state: 'State', strategy=STRATEGY, multi_goal=False):
+    def plan(self, state: 'State', strategy=STRATEGY, multi_goal=False, max_depth= None):
         print("Agent:", self.name, file=sys.stderr)
         print("Planning for goal:", self.goal_details, file=sys.stderr)
-        strategy = Strategy(state, self, strategy=strategy, heuristics=HEURISTICS, metrics=METRICS, multi_goal=multi_goal)
+        strategy = Strategy(state, self, strategy=strategy, heuristics=HEURISTICS, metrics=METRICS, multi_goal=multi_goal, max_depth=max_depth)
         strategy.plan()

--- a/client/strategy.py
+++ b/client/strategy.py
@@ -12,20 +12,20 @@ INF = inf
 
 class Strategy:
     """"Strategy class is responsible for the planning and searching strategies"""
-
     def __init__(self, state: 'State', agent: 'Agent',
-                 strategy='astar',
-                 heuristics='Distance',
-                 metrics='Manhattan',
-                 multi_goal=False):
-
+                  strategy='best-first',
+                  heuristics='Distance'
+                  metrics='Real',
+                  multi_goal=False,
+                  max_depth=None):
+  
         self.state = state
         self.agent = agent
         self.strategy = strategy
         self.heuristics = heuristics
         self.metrics = metrics
         self.multi_goal = multi_goal
-
+        self.max_depth = max_depth
         self.goal_found = False
         self.expanded = set()  # stores expanded states
 
@@ -77,10 +77,13 @@ class Strategy:
             possible_actions = self.agent.getPossibleActions(s)
 
             for action in possible_actions:
-                state_ = s.create_child(action)
-                self.__is_goal__(self.agent, state_, multi_goal=self.multi_goal)
-                if not self.goal_found:
-                    if state_ not in frontier and state_ not in self.expanded:
+                state_ = s.create_child(action, cost=1)
+                self.__is_goal__(self.agent, state_,multi_goal=self.multi_goal)
+
+
+                if not self.goal_found and self.max_depth is not None and s.cost < self.max_depth:
+                    if state_ not in frontier and state_ not in self.expanded and not self.goal_found:
+                        # print(len(frontier), len(self.expanded), file=sys.stderr, flush=True)
                         frontier.append(state_)
 
     def dfs(self):

--- a/client/strategy.py
+++ b/client/strategy.py
@@ -225,7 +225,7 @@ class Strategy:
 
     def extract_plan(self, state: 'State'):
         if state:
-            if self.agent.goal in state.atoms:
+            if not self.multi_goal and self.agent.goal in state.atoms:
                 self.agent.reset_plan()
 
             # print(state.cost, state.h_cost, state.__total_cost__(), file=sys.stderr, flush = True)

--- a/client/utils.py
+++ b/client/utils.py
@@ -226,20 +226,20 @@ def areGoalsMet(state: 'State', goals)-> 'bool':
             return False
     return True
 
-def get_cluster_conflict(who_is_conflicting_with):
+def get_cluster_conflict(who_is_conflicting_with, key_to_remove):
     clusters = []
     all_agents = who_is_conflicting_with.keys()
     for agent in all_agents:
         cluster = find_cluster_of_agent(agent, clusters)
         if cluster is not False:
             for conflicting_agent in who_is_conflicting_with[agent]:
-                if conflicting_agent['status'] == 'blocked':
+                if conflicting_agent['status'] == 'blocked' and conflicting_agent['agent'] not in key_to_remove:
                     cluster.add(conflicting_agent['agent'])
         else:
             cluster = set()
             cluster.add(agent)
             for conflicting_agent in who_is_conflicting_with[agent]:
-                if conflicting_agent['status'] == 'blocked':
+                if conflicting_agent['status'] == 'blocked' and conflicting_agent['agent'] not in key_to_remove:
                     cluster.add(conflicting_agent['agent'])
             clusters.append(cluster)
     return clusters

--- a/levels/initial_levels/SAsoko3_32.lvl
+++ b/levels/initial_levels/SAsoko3_32.lvl
@@ -3,7 +3,7 @@ hospital
 #levelname
 SAsoko3_32
 #colors
-red: 0, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A
+red: 0, A
 #initial
 ++++++++++++++++++++++++++++++++++
 +0A                              +


### PR DESCRIPTION
Make conflict solving more robust: 
- only look for easy solution when planning (stop search at a certain depth limit and a certain number of try) 
- if conflict is ill-posed (most of the time when solving conflict lead to a new conflict) stop everything and replan.